### PR TITLE
fix compiling issue

### DIFF
--- a/tests/CLP.h
+++ b/tests/CLP.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <sstream>
 #include <iostream>
+#include <cstdint>
 
 namespace macoro
 {


### PR DESCRIPTION
The tests seem to not be compiling on my machine due to missing of `std::int64_t`.
By `#include <cstdint>` in the relevant file the issue seems to be resolved.